### PR TITLE
Added org-generate-with-export

### DIFF
--- a/Keg
+++ b/Keg
@@ -6,4 +6,4 @@
  (org-generate
    (recipe . (org-generate :fetcher github :repo "conao3/org-generate.el"))))
 
-(dev-dependency cort)
+(dev-dependency cort with-simulated-input)

--- a/README.org
+++ b/README.org
@@ -224,6 +224,12 @@ Using this package, you can create a project in a generic way without having to 
 Run =M-x org-generate= once you have created a template with an org document. Then, select a template name and actually extract the template.
 When called interactively, it presents the folder where the template is extracted in a =dired=.
 
+Furthermore you can run =M-x org-generate-with-export= which exports the
+template as org before calling =org-generate=. This makes it possible to use
+additional org features inside your template like macro replacements, including
+files or the noweb reference syntax. Some examples are shown in
+[[with-export-examples.org]].
+
 * Customize
 - org-generate-file :: The org file is used as temprate definition.
   (default ={{user-emacs-directory}}/org-generate.org=)

--- a/README.org
+++ b/README.org
@@ -224,15 +224,11 @@ Using this package, you can create a project in a generic way without having to 
 Run =M-x org-generate= once you have created a template with an org document. Then, select a template name and actually extract the template.
 When called interactively, it presents the folder where the template is extracted in a =dired=.
 
-Furthermore you can run =M-x org-generate-with-export= which exports the
-template as org before calling =org-generate=. This makes it possible to use
-additional org features inside your template like macro replacements, including
-files or the noweb reference syntax. Some examples are shown in
-[[with-export-examples.org]].
-
 * Customize
 - org-generate-file :: The org file is used as temprate definition.
   (default ={{user-emacs-directory}}/org-generate.org=)
+- org-generate-with-export-as-org :: If non-nil, the target's definition is exported as org beforehand. By exporting as org before generating it is possible to use some additional org features like including files, macros replacements and the noweb reference syntax. Some examples are shown in [[with-export-examples.org]].
+  (default =nil=)
 
   =M-x org-generate-edit= to edit template file.
 

--- a/README.org
+++ b/README.org
@@ -225,12 +225,16 @@ Run =M-x org-generate= once you have created a template with an org document. Th
 When called interactively, it presents the folder where the template is extracted in a =dired=.
 
 * Customize
-- org-generate-file :: The org file is used as temprate definition.
+- org-generate-file :: The org file is used as template definition. \\
   (default ={{user-emacs-directory}}/org-generate.org=)
-- org-generate-with-export-as-org :: If non-nil, the target's definition is exported as org beforehand. By exporting as org before generating it is possible to use some additional org features like including files, macros replacements and the noweb reference syntax. Some examples are shown in [[with-export-examples.org]].
-  (default =nil=)
-
+  #+HTML: <br>
   =M-x org-generate-edit= to edit template file.
+- org-generate-with-export-as-org :: If non-nil, the target's definition is
+  exported as org beforehand. By exporting as org before generating it is
+  possible to use some additional org features like including files, macros
+  replacements and the noweb reference syntax. Some examples are shown in
+  [[with-export-examples.org]]. \\
+  (default =t=)
 
 * Information
 ** Community

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -28,6 +28,15 @@
 (require 'cort)
 (require 'org-generate)
 
+(defun cort--file-contents (path)
+  "Get all contents of file located at PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (buffer-string)))
+
+
+;;; Test definition
+
 (cort-deftest org-generate/simple
   (cort-generate :equal
     '(((+ 2 3) 5))))
@@ -97,10 +106,8 @@
 #+end_src
 ")
            (org-generate "hugo/page")
-           (with-temp-buffer
-             (insert-file-contents
-              (expand-file-name "page" org-generate/onefile/dir))
-             (buffer-string))))
+           (cort--file-contents
+            (expand-file-name "page" org-generate/onefile/dir))))
        "\
 ---
 title: \"xxx\"

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -396,6 +396,71 @@ title: \"xxx\"
 xxxx
 ")))
 
+(cort-deftest--org-generate org-generate/noweb-reference
+  '(((with-cort--org-generate-buffer "\
+#+NAME: year
+: 2020
+
+#+NAME: whoami
+#+BEGIN_SRC sh
+  # whoami
+  WHOAMI=conao3; echo $WHOAMI
+#+END_SRC
+
+* project
+** general
+*** LICENSE
+#+begin_src text :noweb yes
+  MIT License
+
+  Copyright (c) <<year()>> <<whoami()>>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the \"Software\"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+#+end_src
+"
+       (require 'ob-shell)
+       (org-generate "project/general")
+       (cort--file-contents "LICENSE"))
+     "\
+MIT License
+
+Copyright (c) 2020 conao3
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+")))
+
 ;; (provide 'org-generate-tests)
 
 ;; Local Variables:

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -53,7 +53,9 @@
        (erase-buffer)
        (insert ,contents)
        (goto-char (point-min))
-       ,@body)))
+       (let ((default-directory cort--dir)
+             (buffer-file-name (expand-file-name "temp.org")))
+         ,@body))))
 
 (defmacro cort-deftest--org-generate (name testlst)
   "Define a test case with the NAME.
@@ -308,13 +310,13 @@ xxxx
 ")))
 
 (cort-deftest--org-generate org-generate/include-file
-  '(((with-cort--org-generate-buffer (format "\
+  '(((with-cort--org-generate-buffer "\
 * project
 ** general
 *** LICENSE
-#+INCLUDE: \"%s/mit.txt\" src text
-" cort--dir)
-       (with-temp-file (expand-file-name "mit.txt" cort--dir)
+#+INCLUDE: \"./mit.txt\" src text
+"
+       (with-temp-file "mit.txt"
          (insert "\
 MIT License
 

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -39,6 +39,16 @@
     (insert-file-contents path)
     (buffer-string)))
 
+(defmacro with-cort--org-generate-buffer (contents &rest body)
+  "Exec BODY in temp buffer that has CONTENTS."
+  (declare (indent 1))
+  `(let ((org-generate-root cort--dir)
+         (org-generate--file-buffer (get-buffer-create "*temp*")))
+     (with-current-buffer org-generate--file-buffer
+       (insert ,contents)
+       (goto-char (point-min))
+       ,@body)))
+
 
 ;;; Test definition
 
@@ -50,11 +60,7 @@
   (cort-generate-with-hook :equal
     (lambda () (mkdir cort--dir))
     (lambda () (ignore-errors (delete-directory cort--dir 'force)))
-    '(((let ((org-generate--file-buffer
-              (get-buffer-create "*org-generate*")))
-         (with-current-buffer org-generate--file-buffer
-           (erase-buffer)
-           (insert "\
+    '(((with-cort--org-generate-buffer "\
 * hugo
 ** page
 #+begin_src markdown
@@ -65,8 +71,8 @@
   ### 1. First
   xxxx
 #+end_src
-")
-           (buffer-string)))
+"
+         (buffer-string))
        "\
 * hugo
 ** page
@@ -80,12 +86,7 @@
 #+end_src
 ")
 
-      ((let ((org-generate-root cort--dir)
-             (org-generate--file-buffer
-              (get-buffer-create "*org-generate*")))
-         (with-current-buffer org-generate--file-buffer
-           (erase-buffer)
-           (insert "\
+      ((with-cort--org-generate-buffer "\
 * hugo
 ** page
 *** page
@@ -102,10 +103,10 @@
   ### 2. Second
   yyyy
 #+end_src
-")
-           (org-generate "hugo/page")
-           (cort--file-contents
-            (expand-file-name "page" cort--dir))))
+"
+         (org-generate "hugo/page")
+         (cort--file-contents
+          (expand-file-name "page" cort--dir)))
        "\
 ---
 title: \"xxx\"

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -70,6 +70,26 @@ TESTLST is list of (GIVEN EXPECT)."
 
 (setq org-generate-show-save-message nil)
 
+;; silence test
+;; it maybe hide some important message!
+(progn
+  (require 'ob-emacs-lisp)
+  (fset 'message 'ignore)
+  (defun org-babel-expand-body:emacs-lisp (body params)
+    "Expand BODY according to PARAMS, return the expanded body."
+    (let ((vars (org-babel--get-vars params))
+          (print-level nil)
+          (print-length nil))
+      (if (null vars) (concat body "\n")
+        (format "(let (%s)\n%s\n)"
+                (mapconcat
+                 (lambda (var)
+                   (format "%S"
+                           ;; (print `(,(car var) ',(cdr var)))
+                           `(,(car var) ',(cdr var))))
+                 vars "\n      ")
+                body)))))
+
 (cort-deftest org-generate/simple
   (cort-generate :equal
     '(((+ 2 3) 5))))

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -47,7 +47,8 @@
   "Exec BODY in temp buffer that has CONTENTS."
   (declare (indent 1))
   `(let ((org-generate-root cort--dir)
-         (org-generate--file-buffer (get-buffer-create "*temp*")))
+         (org-generate--file-buffer (get-buffer-create "*temp*"))
+         (org-confirm-babel-evaluate nil))
      (with-current-buffer org-generate--file-buffer
        (erase-buffer)
        (insert ,contents)

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -34,9 +34,9 @@
        temporary-file-directory))
 
 (defun cort--file-contents (path)
-  "Get all contents of file located at PATH."
+  "Get all contents of file located at PATH from `cort--dir'."
   (with-temp-buffer
-    (insert-file-contents path)
+    (insert-file-contents (expand-file-name path cort--dir))
     (buffer-string)))
 
 (defmacro with-cort--org-generate-buffer (contents &rest body)
@@ -105,8 +105,7 @@
 #+end_src
 "
          (org-generate "hugo/page")
-         (cort--file-contents
-          (expand-file-name "page" cort--dir)))
+         (cort--file-contents "page"))
        "\
 ---
 title: \"xxx\"

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -28,7 +28,7 @@
 (require 'cort)
 (require 'org-generate)
 
-(setq dir
+(setq cort--dir
       (expand-file-name
        (format "org-generate-%04d" (random (round 1e4)))
        temporary-file-directory))
@@ -48,8 +48,8 @@
 
 (cort-deftest org-generate/onefile
   (cort-generate-with-hook :equal
-    (lambda () (mkdir dir))
-    (lambda () (ignore-errors (delete-directory dir 'force)))
+    (lambda () (mkdir cort--dir))
+    (lambda () (ignore-errors (delete-directory cort--dir 'force)))
     '(((let ((org-generate--file-buffer
               (get-buffer-create "*org-generate*")))
          (with-current-buffer org-generate--file-buffer
@@ -80,7 +80,7 @@
 #+end_src
 ")
 
-      ((let ((org-generate-root dir)
+      ((let ((org-generate-root cort--dir)
              (org-generate--file-buffer
               (get-buffer-create "*org-generate*")))
          (with-current-buffer org-generate--file-buffer
@@ -105,7 +105,7 @@
 ")
            (org-generate "hugo/page")
            (cort--file-contents
-            (expand-file-name "page" dir))))
+            (expand-file-name "page" cort--dir))))
        "\
 ---
 title: \"xxx\"

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -149,7 +149,7 @@ yyyy
   xxxx
 #+end_src
 "
-       (org-generate-with-export "hugo/page")
+       (org-generate "hugo/page")
        (cort--file-contents "page.md"))
      "\
 ---
@@ -179,7 +179,7 @@ xxxx
 "
        (with-simulated-input
            "awesome RET"
-         (org-generate-with-export "hugo/page"))
+         (org-generate "hugo/page"))
        (cort--file-contents "awesome/page.md"))
      "\
 ---
@@ -213,7 +213,7 @@ xxxx
        (let ((org-generate-root nil))
          (with-simulated-input
              (format "%s RET" cort--dir)
-           (org-generate-with-export "hugo/page")))
+           (org-generate "hugo/page")))
        (cort--file-contents "content/blog/page.md"))
      "\
 ---
@@ -248,7 +248,7 @@ xxxx
 " cort--dir)
        (mkdir (expand-file-name "content/blog" cort--dir) 'parents)
        (let ((org-generate-root nil))
-         (org-generate-with-export "hugo/page"))
+         (org-generate "hugo/page"))
        (cort--file-contents "content/blog/page.md"))
      "\
 ---
@@ -279,7 +279,7 @@ xxxx
 " cort--dir)
        (mkdir (expand-file-name "content/blog" cort--dir) 'parents)
        (let ((org-generate-root nil))
-         (org-generate-with-export "hugo/page"))
+         (org-generate "hugo/page"))
        (cort--file-contents "content/blog/page.md"))
      "\
 ---

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -49,6 +49,16 @@
        (goto-char (point-min))
        ,@body)))
 
+(defmacro cort-deftest--org-generate (name testlst)
+  "Define a test case with the NAME.
+TESTLST is list of (GIVEN EXPECT)."
+  (declare (indent 1))
+  `(cort-deftest ,name
+     (cort-generate-with-hook :equal
+       (lambda () (mkdir cort--dir))
+       (lambda () (ignore-errors (delete-directory cort--dir 'force)))
+       ,testlst)))
+
 
 ;;; Test definition
 
@@ -56,11 +66,8 @@
   (cort-generate :equal
     '(((+ 2 3) 5))))
 
-(cort-deftest org-generate/onefile
-  (cort-generate-with-hook :equal
-    (lambda () (mkdir cort--dir))
-    (lambda () (ignore-errors (delete-directory cort--dir 'force)))
-    '(((with-cort--org-generate-buffer "\
+(cort-deftest--org-generate org-generate/onefile
+  '(((with-cort--org-generate-buffer "\
 * hugo
 ** page
 #+begin_src markdown
@@ -72,8 +79,8 @@
   xxxx
 #+end_src
 "
-         (buffer-string))
-       "\
+       (buffer-string))
+     "\
 * hugo
 ** page
 #+begin_src markdown
@@ -86,7 +93,7 @@
 #+end_src
 ")
 
-      ((with-cort--org-generate-buffer "\
+    ((with-cort--org-generate-buffer "\
 * hugo
 ** page
 *** page
@@ -104,9 +111,9 @@
   yyyy
 #+end_src
 "
-         (org-generate "hugo/page")
-         (cort--file-contents "page"))
-       "\
+       (org-generate "hugo/page")
+       (cort--file-contents "page"))
+     "\
 ---
 title: \"xxx\"
 date: xx/xx/xx
@@ -118,7 +125,7 @@ xxxx
 
 ### 2. Second
 yyyy
-"))))
+")))
 
 ;; (provide 'org-generate-tests)
 

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -366,6 +366,36 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ")))
 
+(cort-deftest--org-generate org-generate/split-template-files
+  '(((with-cort--org-generate-buffer "\
+* hugo
+** page
+#+INCLUDE: hugo.org::*page :only-contents t
+"
+       (with-temp-file "hugo.org"
+         (insert "\
+* page
+** page.md
+#+BEGIN_SRC markdown
+  ---
+  title: \"xxx\"
+  ---
+
+  ### 1. First
+  xxxx
+#+END_SRC
+"))
+       (org-generate "hugo/page")
+       (cort--file-contents "page.md"))
+     "\
+---
+title: \"xxx\"
+---
+
+### 1. First
+xxxx
+")))
+
 ;; (provide 'org-generate-tests)
 
 ;; Local Variables:

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -213,9 +213,9 @@ xxxx
 ")))
 
 (cort-deftest--org-generate org-generate/set-variable-with-macro
-  '(((with-cort--org-generate-buffer (format "\
+  '(((with-cort--org-generate-buffer "\
 #+NAME: hugo-root
-: %s/
+: ./
 #+MACRO: hugo-root (eval (concat \":org-generate-root: \" (org-sbe \"hugo-root\") $1))
 * hugo
 ** page
@@ -231,8 +231,8 @@ xxxx
   ### 1. First
   xxxx
 #+end_src
-" cort--dir)
-       (mkdir (expand-file-name "content/blog" cort--dir) 'parents)
+"
+       (mkdir "content/blog" 'parents)
        (let ((org-generate-root nil))
          (org-generate "hugo/page"))
        (cort--file-contents "content/blog/page.md"))
@@ -246,11 +246,11 @@ xxxx
 ")))
 
 (cort-deftest--org-generate org-generate/set-variable-using-property
-  '(((with-cort--org-generate-buffer (format "\
+  '(((with-cort--org-generate-buffer "\
 #+MACRO: hugo-root-path (eval (concat \":org-generate-root: \" (org-entry-get-with-inheritance \"root\") $1))
 * hugo
 :PROPERTIES:
-:root: %s/
+:root: ./
 :END:
 ** page
 :PROPERTIES:
@@ -265,8 +265,8 @@ xxxx
   ### 1. First
   xxxx
 #+end_src
-" cort--dir)
-       (mkdir (expand-file-name "content/blog" cort--dir) 'parents)
+"
+       (mkdir "content/blog" 'parents)
        (let ((org-generate-root nil))
          (org-generate "hugo/page"))
        (cort--file-contents "content/blog/page.md"))
@@ -279,24 +279,24 @@ title: \"xxx\"
 xxxx
 ")
 
-    ((with-cort--org-generate-buffer (format "\
+    ((with-cort--org-generate-buffer "\
 * hugo
 :PROPERTIES:
-:root: %s/
+:root: ./
 :END:
 #+NAME: root
 #+BEGIN_SRC emacs-lisp :exports none :results raw :var path=\"\"
   (concat \":org-generate-root: \"
           (org-entry-get-with-inheritance \"root\")
-          (format \"%%s\" path))
+          (format \"%s\" path))
 #+END_SRC
 #+MACRO: hugo-root-path (eval (org-sbe \"root\" (path $$1)))
 ** page
 :PROPERTIES:
 {{{hugo-root-path(content/blog/)}}}
 :END:
-" cort--dir)
-       (mkdir (expand-file-name "content/blog" cort--dir) 'parents)
+"
+       (mkdir "content/blog" 'parents)
        (let ((org-generate-root nil))
          (org-generate "hugo/page"))
        (cort--file-contents "content/blog/page.md"))

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -257,6 +257,10 @@ xxxx
 ")
 
     ((with-cort--org-generate-buffer (format "\
+* hugo
+:PROPERTIES:
+:root: %s/
+:END:
 #+NAME: root
 #+BEGIN_SRC emacs-lisp :exports none :results raw :var path=\"\"
   (concat \":org-generate-root: \"
@@ -264,10 +268,6 @@ xxxx
           (format \"%%s\" path))
 #+END_SRC
 #+MACRO: hugo-root-path (eval (org-sbe \"root\" (path $$1)))
-* hugo
-:PROPERTIES:
-:root: %s/
-:END:
 ** page
 :PROPERTIES:
 {{{hugo-root-path(content/blog/)}}}

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -65,6 +65,8 @@ TESTLST is list of (GIVEN EXPECT)."
 
 ;;; Test definition
 
+(setq org-generate-show-save-message nil)
+
 (cort-deftest org-generate/simple
   (cort-generate :equal
     '(((+ 2 3) 5))))

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -49,6 +49,7 @@
   `(let ((org-generate-root cort--dir)
          (org-generate--file-buffer (get-buffer-create "*temp*")))
      (with-current-buffer org-generate--file-buffer
+       (erase-buffer)
        (insert ,contents)
        (goto-char (point-min))
        ,@body)))

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -35,9 +35,12 @@
 
 (defun cort--file-contents (path)
   "Get all contents of file located at PATH from `cort--dir'."
-  (with-temp-buffer
-    (insert-file-contents (expand-file-name path cort--dir))
-    (buffer-string)))
+  (let ((path* (expand-file-name path cort--dir)))
+    (unless (file-readable-p path*)
+      (error "Missing file: %s" path*))
+    (with-temp-buffer
+      (insert-file-contents path*)
+      (buffer-string))))
 
 (defmacro with-cort--org-generate-buffer (contents &rest body)
   "Exec BODY in temp buffer that has CONTENTS."

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -44,14 +44,14 @@
 (cort-deftest org-generate/onefile
   (cort-generate-with-hook :equal
     (lambda ()
-      (setq org-generate/onefile/dir
+      (setq dir
             (expand-file-name
              (format "org-generate-%04d" (random (round 1e4)))
              temporary-file-directory))
-      (mkdir org-generate/onefile/dir))
+      (mkdir dir))
     (lambda ()
       (ignore-errors
-        (delete-directory org-generate/onefile/dir 'force)))
+        (delete-directory dir 'force)))
     '(((let ((org-generate--file-buffer
               (get-buffer-create "*org-generate*")))
          (with-current-buffer org-generate--file-buffer
@@ -82,7 +82,7 @@
 #+end_src
 ")
 
-      ((let ((org-generate-root org-generate/onefile/dir)
+      ((let ((org-generate-root dir)
              (org-generate--file-buffer
               (get-buffer-create "*org-generate*")))
          (with-current-buffer org-generate--file-buffer
@@ -107,7 +107,7 @@
 ")
            (org-generate "hugo/page")
            (cort--file-contents
-            (expand-file-name "page" org-generate/onefile/dir))))
+            (expand-file-name "page" dir))))
        "\
 ---
 title: \"xxx\"

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -127,6 +127,33 @@ xxxx
 yyyy
 ")))
 
+(cort-deftest--org-generate org-genearte/heading-with-macro
+  '(((with-cort--org-generate-buffer "\
+#+OPTIONS: prop:t
+* hugo
+#+MACRO: filename page.md
+** page
+*** {{{filename}}}
+#+begin_src markdown
+  ---
+  title: \"xxx\"
+  ---
+
+  ### 1. First
+  xxxx
+#+end_src
+"
+       (org-generate-with-export "hugo/page")
+       (cort--file-contents "page.md"))
+     "\
+---
+title: \"xxx\"
+---
+
+### 1. First
+xxxx
+")))
+
 ;; (provide 'org-generate-tests)
 
 ;; Local Variables:

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -28,6 +28,11 @@
 (require 'cort)
 (require 'org-generate)
 
+(setq dir
+      (expand-file-name
+       (format "org-generate-%04d" (random (round 1e4)))
+       temporary-file-directory))
+
 (defun cort--file-contents (path)
   "Get all contents of file located at PATH."
   (with-temp-buffer
@@ -43,15 +48,8 @@
 
 (cort-deftest org-generate/onefile
   (cort-generate-with-hook :equal
-    (lambda ()
-      (setq dir
-            (expand-file-name
-             (format "org-generate-%04d" (random (round 1e4)))
-             temporary-file-directory))
-      (mkdir dir))
-    (lambda ()
-      (ignore-errors
-        (delete-directory dir 'force)))
+    (lambda () (mkdir dir))
+    (lambda () (ignore-errors (delete-directory dir 'force)))
     '(((let ((org-generate--file-buffer
               (get-buffer-create "*org-generate*")))
          (with-current-buffer org-generate--file-buffer

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -307,6 +307,63 @@ title: \"xxx\"
 xxxx
 ")))
 
+(cort-deftest--org-generate org-generate/include-file
+  '(((with-cort--org-generate-buffer (format "\
+* project
+** general
+*** LICENSE
+#+INCLUDE: \"%s/mit.txt\" src text
+" cort--dir)
+       (with-temp-file (expand-file-name "mit.txt" cort--dir)
+         (insert "\
+MIT License
+
+Copyright (c) 2020 Naoya Yamashita
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"))
+       (org-generate "project/general")
+       (cort--file-contents "LICENSE"))
+     "\
+MIT License
+
+Copyright (c) 2020 Naoya Yamashita
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the \"Software\"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+")))
+
 ;; (provide 'org-generate-tests)
 
 ;; Local Variables:

--- a/org-generate-tests.el
+++ b/org-generate-tests.el
@@ -133,9 +133,8 @@ xxxx
 yyyy
 ")))
 
-(cort-deftest--org-generate org-genearte/heading-with-macro
+(cort-deftest--org-generate org-generate/heading-with-macro
   '(((with-cort--org-generate-buffer "\
-#+OPTIONS: prop:t
 #+MACRO: filename page.md
 * hugo
 ** page
@@ -160,9 +159,8 @@ title: \"xxx\"
 xxxx
 ")))
 
-(cort-deftest--org-generate org-genearte/heading-with-macro-using-user-input
+(cort-deftest--org-generate org-generate/heading-with-macro-using-user-input
   '(((with-cort--org-generate-buffer "\
-#+OPTIONS: prop:t
 #+MACRO: get-directory (eval (format \"%s/\" (read-string \"Filename: \")))
 * hugo
 ** page
@@ -190,10 +188,10 @@ title: \"xxx\"
 xxxx
 ")))
 
-(cort-deftest--org-generate org-genearte/set-variable-with-macro
-  '(((with-cort--org-generate-buffer "\
-#+OPTIONS: prop:t
+(cort-deftest--org-generate org-generate/set-variable-with-macro
+  '(((with-cort--org-generate-buffer (format "\
 #+NAME: hugo-root
+: %s/
 #+MACRO: hugo-root (eval (concat \":org-generate-root: \" (org-sbe \"hugo-root\") $1))
 * hugo
 ** page
@@ -209,11 +207,10 @@ xxxx
   ### 1. First
   xxxx
 #+end_src
-"
+" cort--dir)
+       (mkdir (expand-file-name "content/blog" cort--dir) 'parents)
        (let ((org-generate-root nil))
-         (with-simulated-input
-             (format "%s RET" cort--dir)
-           (org-generate "hugo/page")))
+         (org-generate "hugo/page"))
        (cort--file-contents "content/blog/page.md"))
      "\
 ---
@@ -224,9 +221,8 @@ title: \"xxx\"
 xxxx
 ")))
 
-(cort-deftest--org-generate org-genearte/set-variable-using-property
+(cort-deftest--org-generate org-generate/set-variable-using-property
   '(((with-cort--org-generate-buffer (format "\
-#+OPTIONS: prop:t
 #+MACRO: hugo-root-path (eval (concat \":org-generate-root: \" (org-entry-get-with-inheritance \"root\") $1))
 * hugo
 :PROPERTIES:
@@ -260,7 +256,6 @@ xxxx
 ")
 
     ((with-cort--org-generate-buffer (format "\
-#+OPTIONS: prop:t
 #+NAME: root
 #+BEGIN_SRC emacs-lisp :exports none :results raw :var path=\"\"
   (concat \":org-generate-root: \"

--- a/org-generate.el
+++ b/org-generate.el
@@ -129,7 +129,7 @@ syntax."
   "Return the string to use for export to org for HEADING in the current buffer.
 The string returned consists of the target's heading and its subtree, its parent
 heading including the content before the first child , and the content before
-the first heading. This is needed to avoid macro replacments in parts that are
+the first heading.  This is needed to avoid macro replacments in parts that are
 not relevant."
   (let* ((start (plist-get (car heading) :begin))
          regions)

--- a/org-generate.el
+++ b/org-generate.el
@@ -190,14 +190,15 @@ If ROOT is non-nil, omit some conditions."
       (if (string-suffix-p "/" title*)
           (mkdir (expand-file-name title* default-directory) 'parent)
         (let ((src
-               (save-restriction
-                 (narrow-to-region
-                  (plist-get heading* :begin) (plist-get heading* :end))
-                 (goto-char (point-min))
-                 (let ((case-fold-search t))
-                   (when (search-forward "#+begin_src" nil 'noerror)
-                     (goto-char (match-beginning 0))))
-                 (org-element-src-block-parser (point-max) nil))))
+               (save-excursion
+                 (save-restriction
+                   (narrow-to-region
+                    (plist-get heading* :begin) (plist-get heading* :end))
+                   (goto-char (point-min))
+                   (let ((case-fold-search t))
+                     (when (search-forward "#+begin_src" nil 'noerror)
+                       (goto-char (match-beginning 0))))
+                   (org-element-src-block-parser (point-max) nil)))))
           (unless src
             (error "Node %s has no src block" title*))
           (let* ((file (expand-file-name title* default-directory))

--- a/org-generate.el
+++ b/org-generate.el
@@ -249,9 +249,10 @@ If ROOT is non-nil, omit some conditions."
                    (vars (funcall fn 'org-generate-variable))
                    (beforehooks (funcall fn 'org-generate-before-hook))
                    (afterhooks  (funcall fn 'org-generate-after-hook)))
-              (setq root (or org-generate-root
-                             (car root)
-                             (read-file-name "Generate root: " dir)))
+              (setq root (expand-file-name
+                          (or org-generate-root
+                              (car root)
+                              (read-file-name "Generate root: " dir))))
               (unless (file-directory-p root)
                 (error "%s is not directory" root))
               (let ((default-directory root)

--- a/org-generate.el
+++ b/org-generate.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020  Naoya Yamashita
 
 ;; Author: Naoya Yamashita <conao3@gmail.com>
-;; Version: 1.0.3
+;; Version: 1.0.4
 ;; Keywords: convenience
 ;; Package-Requires: ((emacs "26.1") (org "9.3") (mustache "0.23"))
 ;; URL: https://github.com/conao3/org-generate.el

--- a/org-generate.el
+++ b/org-generate.el
@@ -56,6 +56,11 @@ syntax."
   :group 'org-generate
   :type 'boolean)
 
+(defcustom org-generate-show-save-message t
+  "If non-nil, show message after save files."
+  :group 'org-generate
+  :type 'boolean)
+
 (defvar org-generate-root nil)
 (defvar org-generate-mustache-info nil)
 (defvar org-generate--file-buffer nil)
@@ -208,7 +213,8 @@ If ROOT is non-nil, omit some conditions."
                  (srcbody* (mustache-render srcbody org-generate-mustache-info)))
             (with-temp-file file
               (insert srcbody*))
-            (message "[org-generate] Saved: %s" file))))
+            (when org-generate-show-save-message
+              (message "[org-generate] Saved: %s" file)))))
       (dolist (elm (cdr heading))
         (let ((default-directory
                 (expand-file-name title* default-directory)))

--- a/org-generate.el
+++ b/org-generate.el
@@ -187,6 +187,8 @@ If ROOT is non-nil, omit some conditions."
                 (title* (mustache-render title org-generate-mustache-info)))
       (when (and (not (string-suffix-p "/" title*)) (cdr heading))
         (error "Heading %s is not suffixed \"/\", but it have childlen" title*))
+      (when (string-empty-p title*)
+        (error "Heading %s will be empty string.  We could not create file with empty name" title))
       (if (string-suffix-p "/" title*)
           (mkdir (expand-file-name title* default-directory) 'parent)
         (let ((src

--- a/org-generate.el
+++ b/org-generate.el
@@ -48,6 +48,14 @@
   :group 'org-generate
   :type 'boolean)
 
+(defcustom org-generate-with-export-as-org nil
+  "If non-nil, the target's definition is exported as org beforehand.
+By exporting as org before generating it is possible to use some additional org
+features like including files, macros replacements and the noweb reference
+syntax."
+  :group 'org-generate
+  :type 'boolean)
+
 (defvar org-generate-root nil)
 (defvar org-generate-mustache-info nil)
 (defvar org-generate--file-buffer nil)
@@ -112,6 +120,51 @@
                 (tmp (funcall fn h2 tmp)))
       tmp)))
 
+(defun org-generate--create-string-for-export (heading)
+  "Return the string to use for export to org for HEADING in the current buffer.
+The string returned consists of the target's heading and its subtree, its parent
+heading including the content before the first child , and the content before
+the first heading. This is needed to avoid macro replacments in parts that are
+not relevant."
+  (let* ((start (plist-get (car heading) :begin))
+         regions)
+    (save-excursion
+      (save-match-data
+        ;; Target heading and its subtree.
+        (push (cons start (plist-get (car heading) :end)) regions)
+        ;; Parent's heading and content.
+        (goto-char start)
+        (org-up-heading-safe)
+        (push (cons (point) (outline-next-heading)) regions)
+        ;; Content before first heading.
+        (goto-char (point-min))
+        (unless (org-at-heading-p)
+          (push (cons (point-min) (outline-next-heading)) regions))))
+    ;; Create the string for export.
+    (apply #'concat
+           (mapcar
+            (lambda (e) (buffer-substring-no-properties (car e) (cdr e)))
+            regions))))
+
+(defun org-generate--export-string-as-org (string)
+  "Export the STRING as org and return the exported string.
+Properties are exported as well."
+  (require 'ox-org)
+  (let ((org-export-with-properties t))
+    (ignore org-export-with-properties)
+    (org-export-string-as string 'org t)))
+
+(defun org-generate--with-export (heading)
+  "Return a new buffer with the definition for HEADING exported as org."
+  (let* ((string-to-export (org-generate--create-string-for-export heading))
+         (exported-string (org-generate--export-string-as-org string-to-export))
+         (export-buffer (generate-new-buffer "*org-generate-temp*")))
+    (with-current-buffer export-buffer
+      (insert exported-string)
+      (let ((org-inhibit-startup t))
+        (org-mode)))
+    export-buffer))
+
 ;;;###autoload
 (defun org-generate-edit ()
   "Open `org-generate-file'."
@@ -160,105 +213,58 @@ If ROOT is non-nil, omit some conditions."
 
 ;;;###autoload
 (defun org-generate (target)
-  "Gerenate files from org document using TARGET definition."
+  "Generate files from org document using TARGET definition."
   (interactive (list
                 (completing-read
                  "Generate: "
                  (org-generate-candidate) nil 'match)))
-  (let ((dir default-directory))
+  (let ((dir default-directory)
+        export-buffer)
     (with-current-buffer (org-generate-file-buffer)
       (let ((heading (org-generate-search-heading target)))
         (unless heading
           (error "%s is not defined at %s" target org-generate-file))
-        (let* ((fn (lambda (elm)
-                     (org-entry-get-multivalued-property
-                      (plist-get (car heading) :begin)
-                      (symbol-name elm))))
-               (root (funcall fn 'org-generate-root))
-               (vars (funcall fn 'org-generate-variable))
-               (beforehooks (funcall fn 'org-generate-before-hook))
-               (afterhooks  (funcall fn 'org-generate-after-hook)))
-          (setq root (or org-generate-root
-                         (car root)
-                         (read-file-name "Generate root: " dir)))
-          (unless (file-directory-p root)
-            (error "%s is not directory" root))
-          (let ((default-directory root)
-                (org-generate-mustache-info
-                 (or org-generate-mustache-info
-                     (org-generate--hash-table-from-alist
-                      (mapcar (lambda (elm)
-                                (cons elm (read-string (format "%s: " elm))))
-                              vars)))))
-            (when beforehooks
-              (dolist (elm beforehooks)
-                (funcall (intern elm))))
+        ;; Export as org to new buffer before if needed.
+        (when org-generate-with-export-as-org
+          (setq export-buffer (org-generate--with-export heading))
+          (set-buffer export-buffer)
+          ;; Update heading positions.
+          (let ((org-generate--file-buffer export-buffer))
+            (setq heading (org-generate-search-heading target))))
+        (unwind-protect
+            (let* ((fn (lambda (elm)
+                         (org-entry-get-multivalued-property
+                          (plist-get (car heading) :begin)
+                          (symbol-name elm))))
+                   (root (funcall fn 'org-generate-root))
+                   (vars (funcall fn 'org-generate-variable))
+                   (beforehooks (funcall fn 'org-generate-before-hook))
+                   (afterhooks  (funcall fn 'org-generate-after-hook)))
+              (setq root (or org-generate-root
+                             (car root)
+                             (read-file-name "Generate root: " dir)))
+              (unless (file-directory-p root)
+                (error "%s is not directory" root))
+              (let ((default-directory root)
+                    (org-generate-mustache-info
+                     (or org-generate-mustache-info
+                         (org-generate--hash-table-from-alist
+                          (mapcar (lambda (elm)
+                                    (cons elm (read-string (format "%s: " elm))))
+                                  vars)))))
+                (when beforehooks
+                  (dolist (elm beforehooks)
+                    (funcall (intern elm))))
 
-            (org-generate-1 t heading)
+                (org-generate-1 t heading)
 
-            (when afterhooks
-              (dolist (elm afterhooks)
-                (funcall (intern elm))))
-            (when (called-interactively-p 'interactive)
-              (dired root))))))))
-
-(defun org-generate--create-string-for-export (target)
-  "Return the string to use for export to org for TARGET definition.
-The string returned consists of the target's heading and its subtree, its parent
-heading including the content before the first child , and the content before
-the first heading. This is needed to avoid macro replacments in parts that are
-not relevant."
-  (with-current-buffer (org-generate-file-buffer)
-    (let ((heading (org-generate-search-heading target)))
-      (unless heading
-        (user-error "%s is not defined at %s" target org-generate-file))
-      (let* ((start (plist-get (car heading) :begin))
-             regions)
-        (save-excursion
-          (save-match-data
-            ;; Target heading and its subtree.
-            (push (cons start (plist-get (car heading) :end)) regions)
-            ;; Parent's heading and content.
-            (goto-char start)
-            (org-up-heading-safe)
-            (push (cons (point) (outline-next-heading)) regions)
-            ;; Content before first heading.
-            (goto-char (point-min))
-            (unless (org-at-heading-p)
-              (push (cons (point-min) (outline-next-heading)) regions))))
-        ;; Create the string for export.
-        (apply #'concat
-               (mapcar
-                (lambda (e) (buffer-substring-no-properties (car e) (cdr e)))
-                regions))))))
-
-(defun org-generate--export-string-as-org (string)
-  "Export the STRING as org and return the exported string.
-Properties are exported as well."
-  (require 'ox-org)
-  (let ((org-export-with-properties t))
-    (org-export-string-as string 'org t)))
-
-;;;###autoload
-(defun org-generate-with-export (target)
-  "Export as org and generate files from org document using TARGET definition.
-By exporting as org before generating it is possible to use some additional org
-features like including files, macros replacements and the noweb reference
-syntax."
-  (interactive (list
-                (completing-read
-                 "Generate: "
-                 (org-generate-candidate) nil 'match)))
-  (let* ((string-to-export (org-generate--create-string-for-export target))
-         (exported-string (org-generate--export-string-as-org string-to-export)))
-    (with-temp-buffer
-      (let ((org-generate--file-buffer (current-buffer)))
-        (insert exported-string)
-        (let ((org-inhibit-startup t))
-          (org-mode))
-        (if (called-interactively-p 'interactive)
-            (funcall-interactively #'org-generate target)
-          (org-generate target))))))
+                (when afterhooks
+                  (dolist (elm afterhooks)
+                    (funcall (intern elm))))
+                (when (called-interactively-p 'interactive)
+                  (dired root))))
+          (when export-buffer
+            (kill-buffer export-buffer)))))))
 
 (provide 'org-generate)
 

--- a/org-generate.el
+++ b/org-generate.el
@@ -48,7 +48,7 @@
   :group 'org-generate
   :type 'boolean)
 
-(defcustom org-generate-with-export-as-org nil
+(defcustom org-generate-with-export-as-org t
   "If non-nil, the target's definition is exported as org beforehand.
 By exporting as org before generating it is possible to use some additional org
 features like including files, macros replacements and the noweb reference

--- a/org-generate.el
+++ b/org-generate.el
@@ -203,10 +203,11 @@ If ROOT is non-nil, omit some conditions."
               (dired root))))))))
 
 (defun org-generate--create-string-for-export (target)
-  "Returns the string to use for export to org for TARGET definition.
-It returns the target's heading and its subtree, its parent heading including
-the content before the first child , and the content before the first heading.
-This is needed to avoid macro replacments in parts that are not relevant."
+  "Return the string to use for export to org for TARGET definition.
+The string returned consists of the target's heading and its subtree, its parent
+heading including the content before the first child , and the content before
+the first heading. This is needed to avoid macro replacments in parts that are
+not relevant."
   (with-current-buffer (org-generate-file-buffer)
     (let ((heading (org-generate-search-heading target)))
       (unless heading
@@ -232,7 +233,7 @@ This is needed to avoid macro replacments in parts that are not relevant."
                 regions))))))
 
 (defun org-generate--export-string-as-org (string)
-  "Exports the STRING as org and returns the exported string.
+  "Export the STRING as org and return the exported string.
 Properties are exported as well."
   (require 'ox-org)
   (let ((org-export-with-properties t))

--- a/org-generate.el
+++ b/org-generate.el
@@ -151,12 +151,12 @@ not relevant."
             (lambda (e) (buffer-substring-no-properties (car e) (cdr e)))
             regions))))
 
+(defvar org-export-with-properties)
 (defun org-generate--export-string-as-org (string)
   "Export the STRING as org and return the exported string.
 Properties are exported as well."
   (require 'ox-org)
   (let ((org-export-with-properties t))
-    (ignore org-export-with-properties)
     (org-export-string-as string 'org t)))
 
 (defun org-generate--with-export (heading)

--- a/org-generate.el
+++ b/org-generate.el
@@ -202,6 +202,42 @@ If ROOT is non-nil, omit some conditions."
             (when (called-interactively-p 'interactive)
               (dired root))))))))
 
+(defun org-generate--create-string-for-export (target)
+  "Returns the string to use for export to org for TARGET definition.
+It returns the target's heading and its subtree, its parent heading including
+the content before the first child , and the content before the first heading.
+This is needed to avoid macro replacments in parts that are not relevant."
+  (with-current-buffer (org-generate-file-buffer)
+    (let ((heading (org-generate-search-heading target)))
+      (unless heading
+        (user-error "%s is not defined at %s" target org-generate-file))
+      (let* ((start (plist-get (car heading) :begin))
+             regions)
+        (save-excursion
+          (save-match-data
+            ;; Target heading and its subtree.
+            (push (cons start (plist-get (car heading) :end)) regions)
+            ;; Parent's heading and content.
+            (goto-char start)
+            (org-up-heading-safe)
+            (push (cons (point) (outline-next-heading)) regions)
+            ;; Content before first heading.
+            (goto-char (point-min))
+            (unless (org-at-heading-p)
+              (push (cons (point-min) (outline-next-heading)) regions))))
+        ;; Create the string for export.
+        (apply #'concat
+               (mapcar
+                (lambda (e) (buffer-substring-no-properties (car e) (cdr e)))
+                regions))))))
+
+(defun org-generate--export-string-as-org (string)
+  "Exports the STRING as org and returns the exported string.
+Properties are exported as well."
+  (require 'ox-org)
+  (let ((org-export-with-properties t))
+    (org-export-string-as string 'org t)))
+
 ;;;###autoload
 (defun org-generate-with-export (target)
   "Export as org and generate files from org document using TARGET definition.
@@ -212,44 +248,13 @@ syntax."
                 (completing-read
                  "Generate: "
                  (org-generate-candidate) nil 'match)))
-  (let (string-to-export)
-    (with-current-buffer (org-generate-file-buffer)
-      (let ((heading (org-generate-search-heading target)))
-        (unless heading
-          (user-error "%s is not defined at %s" target org-generate-file))
-        ;; Export only the target's subtree, it's parent content and everything
-        ;; before the first heading to avoid macro replacements in parts that
-        ;; are not relevant.
-        (let* ((start (plist-get (car heading) :begin))
-               regions)
-          (save-excursion
-            (save-match-data
-              ;; Add the target subtree.
-              (push (cons start (plist-get (car heading) :end)) regions)
-              ;; Add the body of the target's parent.
-              (goto-char start)
-              (org-up-heading-safe)
-              (push (cons (point) (outline-next-heading)) regions)
-              ;; Add the region before the first heading if there is any.
-              (goto-char (point-min))
-              (unless (org-at-heading-p)
-                (push (cons (point-min) (outline-next-heading)) regions))))
-          ;; Create the string for export.
-          (setq string-to-export
-                (apply #'concat "#+OPTIONS: prop:t\n"
-                       (mapcar (lambda (e)
-                                 (buffer-substring-no-properties (car e) (cdr e)))
-                               regions))))))
-    ;; Export the string as org and insert it into a temp buffer. Set
-    ;; `org-generate--file-buffer' to the temp buffer when calling
-    ;; `org-generate'.
-    (require 'ox-org)
+  (let* ((string-to-export (org-generate--create-string-for-export target))
+         (exported-string (org-generate--export-string-as-org string-to-export)))
     (with-temp-buffer
-      (let ((org-generate--file-buffer (current-buffer))
-            (exported-string (org-export-string-as string-to-export 'org)))
+      (let ((org-generate--file-buffer (current-buffer)))
         (insert exported-string)
-        (let ((org-inhibit-startup t)
-              (org-mode)))
+        (let ((org-inhibit-startup t))
+          (org-mode))
         (if (called-interactively-p 'interactive)
             (funcall-interactively #'org-generate target)
           (org-generate target))))))

--- a/with-export-examples.org
+++ b/with-export-examples.org
@@ -123,8 +123,8 @@ the macro as ~$1~.
   ,#+OPTIONS: prop:t
   ,* hugo
   ,#+NAME: hugo-root
-  ,#+MACRO: hugo-root (eval (concat ":org-generate-root: " (org-sbe "hugo-root") $1))
   : ~/dev/repos/hugo-src/
+  ,#+MACRO: hugo-root (eval (concat ":org-generate-root: " (org-sbe "hugo-root") $1))
   ,** page
   :PROPERTIES:
   {{{hugo-root(content/blog/)}}}

--- a/with-export-examples.org
+++ b/with-export-examples.org
@@ -1,0 +1,454 @@
+* Examples for ~org-generate-with-export~
+
+This file contains examples of additional org features available when using
+~org-generate-with-export~. This is by no means complete, there are endless
+possibilities.
+
+Some useful features are (links to the org-mode manual):
+
+- [[https://orgmode.org/manual/Include-Files.html][Include Files]]
+- [[https://orgmode.org/manual/Macro-Replacement.html][Macro Replacement]]
+- [[https://orgmode.org/manual/Noweb-Reference-Syntax.html][Noweb Reference Syntax]]
+- [[https://orgmode.org/manual/Exporting-Code-Blocks.html][Exporting Code Blocks]]
+
+~org-generate-with-export~ exports the target, its parent heading including the
+content before the first child, and the content before the first heading. This
+is important so you know which macros and source blocks are available. In
+addition ~org-generate-with-export~ adds ~#+OPTIONS: prop:t~ to make properties
+get exported.
+
+Use ~M-x org-org-export-as-org~ while inside the org-caputre template buffer to
+see what results you will get before running the function.
+
+Most source block examples to generate results use emacs-lisp. You can use any
+language supported by babel.
+
+** Table of Contents
+
+- [[#use-a-macro-to-set-heading-title][Use a macro to set heading title]]
+- [[#get-user-input-to-set-the-heading-title][Get user input to set the heading title]]
+- [[#get-user-input---avoid-multiple-evaluations][Get user input - avoid multiple evaluations]]
+- [[#set-the-org-generate-root-property-with-a-macro][Set the :org-generate-root: property with a macro]]
+- [[#use-a-property-value-to-set-org-generate-root-with-a-macro][Use a property value to set :org-generate-root: with a macro]]
+- [[#use-variables-from-a-emacs-lisp-list][Use variables from a emacs lisp list]]
+- [[#include-a-file][Include a file]]
+- [[#include-a-file-with-filename-from-argument][Include a file with filename from argument]]
+- [[#split-the-template-into-multiple-files-with-include][Split the template into multiple files with include]]
+- [[#noweb-reference-syntax---include-results-in-source-block][Noweb reference syntax - include results in source block]]
+- [[#exported-source-blocks][Exported source blocks]]
+- [[#inline-source-block][Inline source block]]
+- [[#create-root-directory-if-it-doesnt-exist][Create root directory if it doesn't exist]]
+- [[#use-a-source-block-to-copy-file-below-root][Use a source block to copy file below root]]
+- [[#expand-a-macro-with-elisp][Expand a macro with elisp]]
+- [[#do-something-after-org-generate][Do something after org-generate]]
+
+** Use a macro to set heading title
+
+Set the title of the heading with a macro:
+
+#+BEGIN_SRC org
+  ,#+OPTIONS: prop:t
+  ,* hugo
+  ,#+MACRO: filename page.md
+  ,** page
+  :PROPERTIES:
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+  :END:
+  ,*** {{{filename}}}
+#+END_SRC
+
+The macro is replaced with:
+
+#+BEGIN_SRC org
+  ,*** page.md
+#+END_SRC
+
+** Get user input to set the heading title
+
+Set the title of the heading with a macro. To evaluate emacs lisp inside a macro
+use ~eval~:
+
+#+BEGIN_SRC org
+  ,#+OPTIONS: prop:t
+  ,* hugo
+   ,#+MACRO: get-directory (eval (format "%s/" (read-string "Directory: ")))
+  ,** page
+  :PROPERTIES:
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+  :END:
+  ,*** {{{get-directory}}}
+#+END_SRC
+
+You will be prompted for a directory. If you input ~test~ the macro is replaced
+with:
+
+#+BEGIN_SRC org
+  ,*** test/
+#+END_SRC
+
+** Get user input - avoid multiple evaluations
+
+Each time a macro is expanded any emacs-lisp in it is reevaluated. If you reuse
+a macro that ask you for an input you probably don't want it to ask you over and
+over. To get around use a local variable:
+
+#+BEGIN_SRC org
+  ,#+NAME: licence
+  ,#+BEGIN_SRC emacs-lisp :exports none :results raw :wrap src text
+    (unless (and (boundp 'my-var-licence) my-var-licence)
+      (setq-local my-var-licence (completing-read "Licence: " '("mit" "gplv3") nil t)))
+    (org-export-string-as (concat  "#+INCLUDE: \"~/projects/licences/" my-var-licence ".txt\"") 'org t)
+  ,#+END_SRC
+
+  ,#+CALL: licence()
+  ,#+CALL: licence()
+#+END_SRC
+
+Could use a macro as well with ~org-sbe~:
+
+#+BEGIN_SRC org
+  ,#+MACRO: licence (eval (org-sbe "licence"))
+  {{{licence}}}
+  {{{licence}}}
+#+END_SRC
+
+
+** Set the :org-generate-root: property with a macro
+
+To make this work you have to use a macro that sets the whole line.
+
+~org-sbe~ is used to get the result from the source block named ~hugo-root~
+inside the macro. That function is great to combine macros and source blocks.
+
+The macro uses an argument that can be used when calling the macro and inside
+the macro as ~$1~.
+
+#+BEGIN_SRC org
+  ,#+OPTIONS: prop:t
+  ,* hugo
+  ,#+NAME: hugo-root
+  ,#+MACRO: hugo-root (eval (concat ":org-generate-root: " (org-sbe "hugo-root") $1))
+  : ~/dev/repos/hugo-src/
+  ,** page
+  :PROPERTIES:
+  {{{hugo-root(content/blog/)}}}
+  :END:
+#+END_SRC
+
+The macro line expands to:
+
+#+BEGIN_SRC org
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+#+END_SRC
+
+** Use a property value to set :org-generate-root: with a macro
+
+Uses the value of the inherited property ~root~:
+
+#+BEGIN_SRC org
+  ,#+OPTIONS: prop:t
+  ,#+MACRO: hugo-root-path (eval (concat ":org-generate-root: " (org-entry-get-with-inheritance "root") $1))
+
+  ,* hugo
+  :PROPERTIES:
+  :root:     ~/dev/repos/hugo-src/
+  :END:
+
+  ,** page
+  :PROPERTIES:
+  {{{hugo-root-path(content/blog/)}}}
+  :END:
+#+END_SRC
+
+The macro will be replaced with:
+
+#+BEGIN_SRC org
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+#+END_SRC
+
+This could also be separated into a source block and macro:
+
+#+BEGIN_SRC org
+  ,#+OPTIONS: prop:t
+  ,* hugo
+  :PROPERTIES:
+  :root:     ~/dev/repos/hugo-src/
+  :END:
+
+  ,#+NAME: root
+  ,#+BEGIN_SRC emacs-lisp :exports none :results raw :var path=""
+    (concat ":org-generate-root: " (org-entry-get-with-inheritance "root") (format "%s" path))
+  ,#+END_SRC
+  ,#+MACRO: hugo-root-path (eval (org-sbe "root" (path $$1)))
+
+  ,** page
+  :PROPERTIES:
+  {{{hugo-root-path(content/blog/)}}}
+  :END:
+#+END_SRC
+
+When using a string for a variable with ~org-sbe~ it has to be prefixed with
+another ~$~. Here ~$$1~ or if a string like =$"string"=.
+
+** Use variables from a emacs lisp list
+
+Store variables with emacs lisp and a source block and access them with ~org-sbe~:
+
+#+BEGIN_SRC org
+  ,#+NAME: variables
+  ,#+BEGIN_SRC emacs-lisp
+    '(:folder "~/.emacs.d"
+      :license "mit")
+  ,#+END_SRC
+
+  ,#+NAME: get-var
+  ,#+BEGIN_SRC emacs-lisp :var vars=variables var=""
+    (plist-get vars (intern-soft var))
+  ,#+END_SRC
+
+  ,#+MACRO: emacs-test (eval (org-sbe "get-var" (var $$1)))
+  {{{emacs-test(:folder)}}}
+#+END_SRC
+
+The macro is expanded into:
+
+#+BEGIN_SRC org
+  ~/.emacs.d
+#+END_SRC
+
+** Include a file
+
+Include another file at any place in your template. Make sure it is wrapped in a
+block if needed.
+
+#+BEGIN_SRC org
+  ,#+INCLUDE: "~/projects/licences/gplv3.txt" src text
+  ,#+INCLUDE: "~/.emacs.d/init.el" src emacs-lisp
+  ,#+INCLUDE: "./paper.org::#theory" :only-contents t
+#+END_SRC
+
+Macros in an included file get replaced as well. An include in an included org
+file works as well.
+
+** Include a file with filename from argument
+
+Found two solutions for this, with org and exporting one just needs to get
+a bit creative sometimes.
+
+First one uses ~org-export-string-as~. This function could actually be used for
+a lot of other stuff as well.
+
+#+BEGIN_SRC org
+  ,#+MACRO: include-file (eval (org-export-string-as (concat "#+INCLUDE: \"~/projects/licences/" $1 ".txt\" src text") 'org t))
+  {{{include-file(gplv3)}}}
+#+END_SRC
+
+The second solution expands the macro to insert the ~#+INCLUDE: ...~ and uses a
+macro to trigger the expansion. This is needed as the macros are replaced after
+inclusion and therefore the file would never be included.
+
+#+BEGIN_SRC org
+  ,#+MACRO: include #+INCLUDE: "~/projects/licences/$1.txt" src text
+  ,#+MACRO: include-expand (eval (progn (org-export-expand-include-keyword) ""))
+  {{{include(gplv3)}}}
+  {{{include-expand}}}
+#+END_SRC
+
+** Split the template into multiple files with include
+
+Include files to split the template into multiple files. This example includes
+the contents from the heading ~page~ found in ~hugo.org~ inside the directory
+where ~org-generate.org~ is placed:
+
+#+BEGIN_SRC org
+  ,#+OPTIONS: prop:t
+  ,* hugo
+  ,** page
+  :PROPERTIES:
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+  :END:
+  ,#+INCLUDE: hugo.org::*page :only-contents t
+#+END_SRC
+
+The file ~hugo.org~ has the following content:
+
+#+BEGIN_SRC org
+  ,* page
+  :PROPERTIES:
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+  :END:
+  ,** text.txt
+  ,#+BEGIN_SRC text
+    Some text
+  ,#+END_SRC
+#+END_SRC
+
+This is exported as:
+
+#+BEGIN_SRC org
+  ,* hugo
+  ,** page
+  :PROPERTIES:
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
+  :END:
+  ,*** text.txt
+  ,#+begin_src text
+    Some text
+  ,#+end_src
+#+END_SRC
+
+** Noweb reference syntax - include results in source block
+
+Include the code or the result of other source blocks with noweb. Check the the
+Noweb Reference Syntax in the [[https://orgmode.org/manual/Noweb-Reference-Syntax.html][org manual]].
+
+An example with a simple named block and a shell source block:
+
+#+BEGIN_SRC org
+  ,#+NAME: year
+  : 2020
+
+  ,#+NAME: whoami
+  ,#+BEGIN_SRC sh
+    whoami
+  ,#+END_SRC
+
+  ,#+BEGIN_SRC emacs-lisp :noweb yes
+    ;; by <<whoami()>> in <<year()>>
+  ,#+END_SRC
+#+END_SRC
+
+The emacs source block will be exported to:
+
+#+BEGIN_SRC org
+  ,#+begin_src emacs-lisp
+    ;; by hubisan in 2020
+  ,#+end_src
+#+END_SRC
+
+** Exported source blocks
+
+In the header arguments of the source code you can define what will be exported
+(~:exports code~, ~:exports result~, ~:exports both~, ~:exports none~).
+
+This can for instance be used to insert the results of a source block. In this
+case to include a file with emacs-lisp.
+
+#+BEGIN_SRC org
+  ,#+BEGIN_SRC emacs-lisp :exports results :results raw :wrap src text
+    (org-export-string-as "#+INCLUDE: \"~/projects/licences/gplv3.txt\"" 'org t)
+  ,#+END_SRC
+#+END_SRC
+
+ The result gets wrapped  in a source block (~:wrap src text~) and the code is not
+ exported because of the header arguments ~:exports: results~.
+
+** Inline source block
+
+You can use an inline source block. Only downside is that you can't get rid of
+the spaces around it as far as I know.
+
+#+BEGIN_SRC org
+  This is some src_elisp[:results raw]{(concat "inline" "-" "code")}.
+#+END_SRC
+
+After exporting this looks as follows:
+
+#+BEGIN_SRC org
+  This is some inline-code.
+#+END_SRC
+
+** Create root directory if it doesn't exist
+
+This creates the root directory if it doesn't exist, and if necessary the parent
+directories.
+
+#+BEGIN_SRC org
+  ,* Example
+
+  ,#+NAME: create-root
+  ,#+BEGIN_SRC emacs-lisp :exports none :results silent :var source="" dest=""
+    (let* ((copy-root (org-entry-get-with-inheritance "org-generate-root"))
+           (unless (file-exists-p copy-dir)
+             (make-directory copy-dir t))
+  ,#+END_SRC
+
+  ,** Project
+  :PROPERTIES:
+  :org-generate-root: ~/org-generate-test/
+  :END:
+
+  ,#+CALL: create-root()
+
+  ,*** text.txt
+  ,#+BEGIN_SRC text
+    Some text.
+  ,#+END_SRC
+#+END_SRC
+
+** Use a source block to copy file below root
+
+Copy in this case an image to the root. The directory is created if it doesn't
+exist.
+
+#+BEGIN_SRC org
+  ,* Example
+
+  ,#+NAME: copy-image
+  ,#+BEGIN_SRC emacs-lisp :exports none :results silent :var source="" dest=""
+    (let* ((copy-root (org-entry-get-with-inheritance "org-generate-root"))
+           (copy-fname (expand-file-name (concat copy-root dest)))
+           (copy-dir (file-name-directory copy-fname)))
+      ;; Create the directory if it doesn't exist.
+      (unless (file-exists-p copy-dir)
+        (make-directory copy-dir t))
+      (copy-file source copy-fname t))
+  ,#+END_SRC
+
+  ,** Project
+  :PROPERTIES:
+  :org-generate-root: ~/org-generate-test/
+  :END:
+
+  ,#+CALL: copy-image(source="~/image.png", dest="img/image.png")
+
+  ,*** text.txt
+  ,#+BEGIN_SRC text
+  Some text.
+  ,#+END_SRC
+#+END_SRC
+
+** Expand a macro with elisp
+
+To expand a macro with elisp you can call ~org-macro-expand~ as follows:
+
+#+BEGIN_SRC emacs-lisp
+  (org-macro-expand '(macro (:key "author" :args nil)) org-macro-templates)
+  (org-macro-expand '(macro (:key "property" :args ("prop"))) org-macro-templates)
+#+END_SRC
+
+This could be useful for ~org-sbe~ or to use the macro with the noweb reference
+syntax in a source block.
+
+** Do something after org-generate
+
+Use an advice to do something after generating:
+
+#+BEGIN_SRC org
+  ,* Project
+  ,#+NAME: after-org-generate
+  ,#+BEGIN_SRC emacs-lisp :exports none :results silent
+    (advice-add 'org-generate
+                :after
+                (lambda (&rest r)
+                  (message "%s" "this is called after")
+                  (advice-remove 'org-generate "my-org-generate-advice"))
+                '((name . "my-org-generate-advice")))
+  ,#+END_SRC
+
+  ,** test
+  :PROPERTIES:
+  :org-generate-root: ~/example/
+  :END:
+  ,#+CALL: after-org-generate()
+#+END_SRC

--- a/with-export-examples.org
+++ b/with-export-examples.org
@@ -1,8 +1,8 @@
 * Examples for ~org-generate-with-export~
 
 This file contains examples of additional org features available when using
-~org-generate-with-export~. This is by no means complete, there are endless
-possibilities.
+~org-generate-with-export-as-org~ is set to ~t~. This is by no means complete,
+there are endless possibilities.
 
 Some useful features are (links to the org-mode manual):
 
@@ -11,17 +11,13 @@ Some useful features are (links to the org-mode manual):
 - [[https://orgmode.org/manual/Noweb-Reference-Syntax.html][Noweb Reference Syntax]]
 - [[https://orgmode.org/manual/Exporting-Code-Blocks.html][Exporting Code Blocks]]
 
-~org-generate-with-export~ exports the target, its parent heading including the
-content before the first child, and the content before the first heading. This
-is important so you know which macros and source blocks are available. In
-addition ~org-generate-with-export~ adds ~#+OPTIONS: prop:t~ to make properties
-get exported.
+If enabled it exports target's heading and its subtree, its parent heading
+including the content before the first child , and the content before the first
+heading. This is important so you know which macros and source blocks are
+available.
 
-Use ~M-x org-org-export-as-org~ while inside the org-caputre template buffer to
+Use ~M-x org-org-export-as-org~ while inside the org-capture template buffer to
 see what results you will get before running the function.
-
-Most source block examples to generate results use emacs-lisp. You can use any
-language supported by babel.
 
 ** Table of Contents
 
@@ -432,23 +428,23 @@ syntax in a source block.
 
 ** Do something after org-generate
 
-Use an advice to do something after generating:
+~org-generate~ supports a property to set functions to call before or after.
+This examples uses a source block to define the function that will be called
+after. Like this you can have everything in the template and you don't have to
+define the function somewhere else.
 
 #+BEGIN_SRC org
   ,* Project
-  ,#+NAME: after-org-generate
-  ,#+BEGIN_SRC emacs-lisp :exports none :results silent
-    (advice-add 'org-generate
-                :after
-                (lambda (&rest r)
-                  (message "%s" "this is called after")
-                  (advice-remove 'org-generate "my-org-generate-advice"))
-                '((name . "my-org-generate-advice")))
-  ,#+END_SRC
-
   ,** test
   :PROPERTIES:
   :org-generate-root: ~/example/
+  :org-generate-after-hook: my-called-after
   :END:
+
+  ,#+NAME: after-org-generate
+  ,#+BEGIN_SRC emacs-lisp :exports none :results silent
+    (defun my-called-after ()
+      (message "called after"))
+  ,#+END_SRC
   ,#+CALL: after-org-generate()
 #+END_SRC

--- a/with-export-examples.org
+++ b/with-export-examples.org
@@ -17,7 +17,10 @@ heading. This is important so you know which macros and source blocks are
 available.
 
 Use ~M-x org-org-export-as-org~ while inside the org-capture template buffer to
-see what results you will get before running the function.
+see what results you will get before running the function. Make sure to add
+~#+OPTIONS: prop:t~ at the top if any properties need to be exported (this is
+not needed for the actually export as ~org-generate~ automatically exports the
+properties).
 
 ** Table of Contents
 
@@ -108,7 +111,6 @@ Could use a macro as well with ~org-sbe~:
   {{{licence}}}
 #+END_SRC
 
-
 ** Set the :org-generate-root: property with a macro
 
 To make this work you have to use a macro that sets the whole line.
@@ -162,7 +164,11 @@ The macro will be replaced with:
   :org-generate-root: ~/dev/repos/hugo-src/content/blog/
 #+END_SRC
 
-This could also be separated into a source block and macro:
+This could also be separated into a source block and macro. While the macro is
+evaluated at the place you use it (each time), the source block is evaluated
+where it actually is even when calling from a macro. Therefore it needs to be
+moved below the heading to make it work. This means that it will always use the
+same root and therefore it is not a good solution for this:
 
 #+BEGIN_SRC org
   ,#+OPTIONS: prop:t
@@ -181,6 +187,22 @@ This could also be separated into a source block and macro:
   :PROPERTIES:
   {{{hugo-root-path(content/blog/)}}}
   :END:
+
+  ,* another
+  :PROPERTIES:
+  :root:     ~/another/
+  :END:
+
+  ,** page
+  :PROPERTIES:
+  {{{hugo-root-path(content/blog/)}}}
+  :END:
+#+END_SRC
+
+In this case both are unexpectedly replaced with:
+
+#+BEGIN_SRC org
+  :org-generate-root: ~/dev/repos/hugo-src/content/blog/
 #+END_SRC
 
 When using a string for a variable with ~org-sbe~ it has to be prefixed with


### PR DESCRIPTION
This solves #3

Decided to make this a wrapping function and not touch org-generate. Mentioned it in the README.org and added some examples in a separate file.

The function works as follows:

1. The function takes the relevant content as string. This is needed as when exporting all macros are expanded even in parts that are not exported.
2. The strings are concatenated and exported as org. There is an built-in org function which takes a string.
3. The exported string is then inserted into a temp buffer.
4. Org-generate is called with lexical binding the buffer to that temporary buffer.

## No tests added so far

Not familiar with cort, not sure how the tests work atm with setup and teardown.

As it is actually just a wrapper around `org-generate` just checking if the relevant parts get exported with a macro replacement should do it. When callling `(org-generate-with-export "Test/Target")` on this:

```org-mode
#+TITLE: Test
#+AUTHOR: Tester
#+MACRO: test success
* Test
:PROPERTIES:
:CUSTOM_ID: test-value
:END:
#+MACRO: test-1 success
** Not exported
:PROPERTIES:
:org-generate-root: ~/projects/
:END:
** Target
:PROPERTIES:
:org-generate-root: ~/test/
:END:
#+MACRO: test-2 success
{{{test}}}
{{{test-1}}}
{{{test-2}}}
* Another 
** Not exported
```

Should be exported to:

```org-mode
# Created 2020-07-13 Mon 17:41
#+TITLE: Test
#+AUTHOR: Tester
#+macro: test success
* Test
:PROPERTIES:
:CUSTOM_ID: test-value
:END:
#+macro: test-1 success
** Target
:PROPERTIES:
:org-generate-root: ~/test/
:END:
#+macro: test-2 success
success
success
success
```

Could advice `org-generate` and replace to check the content of the temporary buffer before `org-generate` is called.