### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
           - emacs_version: 'snapshot'
             allow_failure: true
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1.1.1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - uses: purcell/setup-emacs@master
         with:
           version: ${{ matrix.emacs_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - '26.1'
-          - '26.2'
-          - '26.3'
-          - '27.1'
-          - 'snapshot'
+          - 29.4
+          - snapshot
         include:
           - emacs_version: 'snapshot'
             allow_failure: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Main workflow
 on:
-  push: {branches: [master]}
-  pull_request: {branches: [master]}
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
master branchでGitHub Actionsが落ちているので修正対応した。
https://github.com/conao3/org-generate.el/actions/runs/9916424010

- 9f81f1d0dcdb4a766c2b77b9585f1cf861fd80d6 emacs support version を `29.4` と `snapshot` に変更
- b56cd85eb0043590dcb7b03fd2ef770b0487c01c actionsのversionが低いので修正
- cee167c12d786e32e345b82941fb0992e6947370 event triggerの記述方法を修正
    - `master push` と `pull request` のみでCIが回れば良い